### PR TITLE
Feat: Add Prowler Security Scan Workflow

### DIFF
--- a/.github/workflows/prowler-scan.yml
+++ b/.github/workflows/prowler-scan.yml
@@ -1,0 +1,36 @@
+name: 'Prowler Security Scan'
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 2 * * *' # Runs daily at 2 AM UTC
+
+jobs:
+  prowler-scan:
+    name: 'Prowler Scan'
+    runs-on: ubuntu-latest
+    permissions:
+      security_events: write # Required to upload SARIF results
+
+    steps:
+      - name: 'Checkout'
+        uses: actions/checkout@v3
+
+      - name: 'Configure AWS Credentials'
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-east-1
+
+      - name: 'Install Prowler'
+        run: pip install prowler
+
+      - name: 'Run Prowler Scan'
+        run: prowler aws --output-formats sarif --output-directory . --output-filename prowler-report
+        continue-on-error: true # Continue so the report is always uploaded
+
+      - name: 'Upload SARIF report'
+        uses: github/codeql-action/upload-sarif@v2
+        with:
+          sarif_file: 'prowler-report.sarif'


### PR DESCRIPTION
This commit introduces a new GitHub Actions workflow to perform automated security scans of the AWS environment using Prowler.

The new workflow (`.github/workflows/prowler-scan.yml`) is configured to run on a nightly schedule and can also be triggered manually.

Key features of this workflow include:
- Securely authenticating with AWS using repository secrets.
- Installing the latest version of Prowler.
- Running a comprehensive scan against the AWS account.
- Generating a report in SARIF format.
- Uploading the SARIF report to the GitHub Security tab for easy analysis and tracking of findings.

This enhances the project's DevSecOps capabilities by adding continuous, post-deployment security posture monitoring, complementing the existing pre-deployment checks.